### PR TITLE
[SDK-561] disable keep-alive for ECS health check calls

### DIFF
--- a/src/main/java/com/emc/rest/smart/ecs/EcsHostListProvider.java
+++ b/src/main/java/com/emc/rest/smart/ecs/EcsHostListProvider.java
@@ -100,7 +100,9 @@ public class EcsHostListProvider implements HostListProvider {
     @Override
     public void runHealthCheck(Host host) {
         // header is workaround for STORAGE-1833
-        PingResponse response = client.resource(getRequestUri(host, "/?ping")).header("x-emc-namespace", "x")
+        PingResponse response = client.resource(getRequestUri(host, "/?ping"))
+                .header("x-emc-namespace", "x")
+                .header("Connection", "close") // make sure maintenance calls are not kept alive
                 .get(PingResponse.class);
 
         if (host instanceof VdcHost) {
@@ -144,6 +146,8 @@ public class EcsHostListProvider implements HostListProvider {
         // add date and auth headers
         request.header("Date", rfcDate);
         request.header("Authorization", "AWS " + user + ":" + signature);
+        // make sure maintenance calls are not kept alive
+        request.header("Connection", "close");
 
         // make REST call
         log.debug("retrieving VDC node list from {}", host.getName());


### PR DESCRIPTION
* added "Connection: close" headers to health-check and endpoint enumeration calls in EcsHostListProvider
* added EcsHostListProviderTest test case to verify all connections are closed immediately in EcsHostListProvider (also refactored this class to remove duplicate code)