### PR TITLE
fixed exception with threaded usage

### DIFF
--- a/src/main/java/com/emc/rest/smart/SmartClientFactory.java
+++ b/src/main/java/com/emc/rest/smart/SmartClientFactory.java
@@ -147,7 +147,9 @@ public final class SmartClientFactory {
         ClientConfig clientConfig = new DefaultClientConfig();
 
         // set up multi-threaded connection pool
-        org.apache.http.impl.conn.PoolingHttpClientConnectionManager connectionManager = new org.apache.http.impl.conn.PoolingHttpClientConnectionManager();
+        // TODO: find a non-deprecated connection manager that works (swapping out with
+        //       PoolingHttpClientConnectionManager will break threading)
+        org.apache.http.impl.conn.PoolingClientConnectionManager connectionManager = new org.apache.http.impl.conn.PoolingClientConnectionManager();
         // 999 maximum active connections (max allowed)
         connectionManager.setDefaultMaxPerRoute(999);
         connectionManager.setMaxTotal(999);


### PR DESCRIPTION
PoolingClientConnectionManager is deprecated in the referenced version of httpclient, but apparently its replacement (PoolingHttpClientConnectionManager) has different behavior that breaks our usage, so we have to continue using the deprecated class for now